### PR TITLE
tiny typo: complile -> compile

### DIFF
--- a/toolkit/scaffold-eth-toolbox/scaffold-eth-commands.md
+++ b/toolkit/scaffold-eth-toolbox/scaffold-eth-commands.md
@@ -12,7 +12,7 @@ yarn install
 
 `yarn start` starts a react frontend server at `localhost:3000`
 
-`yarn complile` compiles any smart contracts located at `packages/hardhat/contracts/`
+`yarn compile` compiles any smart contracts located at `packages/hardhat/contracts/`
 
 `yarn deploy` deploys any smart contracts that have been specified in `00_deploy_your_contract.js` located at `packages/hardhat/deploy/`
 


### PR DESCRIPTION
Hey folks, thanks for making scaffold-eth, your content is so well done and super didactic.

I found this tiny typo, I remember that me myself typed complile instead of compile a few times. I must have been thinking of lilies and compilers. Anyhoo, thanks again for this amazing project. 🙏🏽 