### PR TITLE
Typo massage -> message Signator.io

### DIFF
--- a/community/overview/signator.io-built-with.md
+++ b/community/overview/signator.io-built-with.md
@@ -2,7 +2,7 @@
 
 
 
-A simple app that lets you sign a massage with an Ethereum account & generate shareable proof-of-signature links. \
+A simple app that lets you sign a message with an Ethereum account & generate shareable proof-of-signature links. \
 \
 Check it out at [signator.io](https://signator.io/)\
 \


### PR DESCRIPTION
Just a littel typo in Signator.io page in the documentation.

Fixes scaffold-eth/scaffold-eth#859